### PR TITLE
Added quit action

### DIFF
--- a/config/bindings.ron
+++ b/config/bindings.ron
@@ -6,5 +6,6 @@
   actions: {
     "toggle_colliders": [[Key(F2)]],
     "attack": [[Key(Space)]],
+    "quit": [[Key(Q)]],
   },
 )

--- a/src/systems/player_control.rs
+++ b/src/systems/player_control.rs
@@ -3,6 +3,7 @@ use amethyst::{
     ecs::prelude::*,
     input::{InputHandler, StringBindings},
 };
+use std::process;
 
 use crate::components::{BoxCollider, Damage, KillAfterCollision, KillAfterTime, Player};
 
@@ -71,9 +72,11 @@ impl<'s> System<'s> for PlayerControlSystem {
             // Custom bindings might be better for the future but right now
             // this is good enough
             // https://book.amethyst.rs/stable/input/how_to_define_custom_control_bindings.html
+            if let Some(should_quit) = input.action_is_down("quit"){
+                should_quit && process::exit(0);
+            }
             let x_movement = input.axis_value("x_axis").unwrap_or(0.);
             let y_movement = input.axis_value("y_axis").unwrap_or(0.);
-
             // Normalizing a vector of length 0 will result in a panic
             // Not very rusty but we have to check to make sure the movement isn't
             // (0.0, 0.0)


### PR DESCRIPTION
This may be moved from actions to just a button check later. Escape was originally going to be used but was not supported.

The current implementation results in a warning, but this should be more elegant anyway with a confirmation screen minimally. If it causes issues while debugging we can hide it behind a feature flag.