### PR TITLE
Replaced usages of `println` macro with log crate macros.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,11 +1001,10 @@ dependencies = [
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
- "cfg-if",
  "libc",
  "redox_users",
  "winapi",
@@ -2176,9 +2175,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53181dcd37421c08d3b69f887784956674d09c3f9a47a04fece2b130a5b346b"
+checksum = "d508492eeb1e5c38ee696371bf7b9fc33c83d46a7d451606b96458fbbbdc2dec"
 dependencies = [
  "paste-impl",
  "proc-macro-hack",
@@ -2186,9 +2185,9 @@ dependencies = [
 
 [[package]]
 name = "paste-impl"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ca490fa1c034a71412b4d1edcb904ec5a0981a4426c9eb2128c0fda7a68d17"
+checksum = "84f328a6a63192b333fce5fbb4be79db6758a4d518dfac6d54412f1492f72d32"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2 1.0.18",
@@ -3375,6 +3374,7 @@ version = "0.1.0"
 dependencies = [
  "amethyst",
  "cargo-husky",
+ "log",
  "rand 0.7.3",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,10 @@ categories = ["games"]
 amethyst = "0.15.0"
 serde = { version = "1.0.110", features = ["derive"] }
 rand = "0.7.3"
+log = "0.4.8"
 
 [dev-dependencies.cargo-husky]
-version = "1"
+version = "1.5.0"
 default-features = false
 features = ["precommit-hook", "run-cargo-clippy", "run-cargo-fmt", "run-cargo-test"]
 

--- a/src/components/enemy.rs
+++ b/src/components/enemy.rs
@@ -7,6 +7,7 @@ use amethyst::{
     },
     prelude::*,
 };
+use log::trace;
 
 pub const HITCIRCLE_RADIUS: f32 = 4.0;
 
@@ -17,7 +18,7 @@ impl Component for Enemy {
 }
 
 pub fn spawn_enemy(world: &mut World, enemy_x: f32, enemy_y: f32, x_vel: f32, y_vel: f32) {
-    println!("Spawning an enemy");
+    trace!("Spawning an enemy");
     let mut t = Transform::default();
     t.set_translation_xyz(enemy_x, enemy_y, 0.0);
     world

--- a/src/sushi_cutters.rs
+++ b/src/sushi_cutters.rs
@@ -1,7 +1,6 @@
 ///! Core `SushiCutters` module
 ///! There is a bit of code that was taken from the pong example which will be phased out in time
 use crate::{components::initialize_player, scenes, scenes::SceneInitializer};
-
 use amethyst::{
     assets::Loader,
     core::transform::Transform,
@@ -11,6 +10,7 @@ use amethyst::{
     ui::{Anchor, TtfFormat, UiText, UiTransform},
     winit::{Event, WindowEvent},
 };
+use log::{info, warn};
 
 extern crate rand;
 
@@ -39,10 +39,10 @@ impl SimpleState for SceneSelect {
     fn on_start(&mut self, data: StateData<'_, GameData<'_, '_>>) {
         initialize_score(data.world);
 
-        println!("Please select a scene (screen must be in focus)");
+        info!("Please select a scene (screen must be in focus)");
 
         for (index, scene) in scenes::SCENES.iter().enumerate() {
-            println!("{}: {}", index, scene.name);
+            info!("{}: {}", index, scene.name);
         }
 
         // TODO: Generate UI
@@ -70,7 +70,7 @@ impl SimpleState for SceneSelect {
                             let initializer = Some(s[num].initializer);
                             return SimpleTrans::Switch(Box::new(SushiCutters { initializer }));
                         } else {
-                            println!("{} is out of bounds", num);
+                            warn!("{} is out of bounds", num);
                         }
                     }
                 }

--- a/src/systems/damage.rs
+++ b/src/systems/damage.rs
@@ -1,4 +1,5 @@
 use amethyst::ecs::prelude::*;
+use log::debug;
 
 use crate::components::{Collisions, Damage, Health};
 
@@ -24,13 +25,13 @@ impl<'s> System<'s> for DamageSystem {
                 // If the collidee has a health component reduce it by damage units
                 if let Some(health) = healths.get_mut(collision.entity) {
                     health.amount -= damage.amount;
-                    println!(
+                    debug!(
                         "{:?} took {} damage ({} health left)",
                         collision.entity, damage.amount, health.amount
                     );
                     // If the health of the target is less than 0 then delet this
                     if health.amount <= 0.0 {
-                        println!("{:?} kicked the bucket", collision.entity);
+                        debug!("{:?} kicked the bucket", collision.entity);
                         entities
                             .delete(collision.entity)
                             .expect("Something wrong happened");


### PR DESCRIPTION
Although not very well documented (IMO), [Amethyst will use `log` crate behind the scenes](https://github.com/amethyst/amethyst/blob/master/src/app.rs#L73-L132). Oddly all of the showcase games they have use `println!`. Not sure why this isn't recommended more heavily by them.

Closes #26

> Maybe also add a lint rule against using `print!` and `println!`.

`clippy::print_stdout` [exists](https://rust-lang.github.io/rust-clippy/master/index.html#print_stdout) but Clippy seems to not care
```rust
#![deny(clippy::print_stdout)]
```
seemingly does nothing, despite being recognized as valid.