### PR TITLE
Feature scaled enemy scene

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
         "Srgba",
         "bumpalo",
         "clippy",
+        "consts",
         "delet",
         "filt",
         "hibitset",

--- a/run_benches
+++ b/run_benches
@@ -4,8 +4,11 @@ rm bench.out
 ./copy_assets
 cargo build --release --features=benchmark
 
-for i in 5000 1000 500 100 50 10; do
-	export ENEMY_COUNT=$i
-	echo "ENEMY_COUNT=$i" >>bench.out
-	target/release/sushi_cutters enemies_bench
+for name in enemies_scaled enemies_bench; do
+	for i in 5000 1000 500 100 50 10; do
+		export ENEMY_COUNT=$i
+		echo "ENEMY_COUNT=$i" >>bench.out
+		target/release/sushi_cutters $name
+	done
+	mv bench.out bench.out.$name
 done

--- a/src/components/enemy.rs
+++ b/src/components/enemy.rs
@@ -9,23 +9,26 @@ use amethyst::{
 };
 use log::trace;
 
-pub const HITCIRCLE_RADIUS: f32 = 4.0;
-
 #[derive(Default)]
 pub struct Enemy;
 impl Component for Enemy {
     type Storage = NullStorage<Self>;
 }
 
-pub fn spawn_enemy(world: &mut World, enemy_x: f32, enemy_y: f32, x_vel: f32, y_vel: f32) {
+pub fn spawn_enemy(
+    world: &mut World,
+    enemy_x: f32,
+    enemy_y: f32,
+    x_vel: f32,
+    y_vel: f32,
+    size: f32,
+) {
     trace!("Spawning an enemy");
     let mut t = Transform::default();
     t.set_translation_xyz(enemy_x, enemy_y, 0.0);
     world
         .create_entity()
-        .with(CircleCollider {
-            radius: HITCIRCLE_RADIUS,
-        })
+        .with(CircleCollider { radius: size })
         .with(Enemy)
         .with(Velocity {
             value: Vector3::new(x_vel, y_vel, 0.0),

--- a/src/components/enemy.rs
+++ b/src/components/enemy.rs
@@ -21,14 +21,14 @@ pub fn spawn_enemy(
     enemy_y: f32,
     x_vel: f32,
     y_vel: f32,
-    size: f32,
+    radius: f32,
 ) {
     trace!("Spawning an enemy");
     let mut t = Transform::default();
     t.set_translation_xyz(enemy_x, enemy_y, 0.0);
     world
         .create_entity()
-        .with(CircleCollider { radius: size })
+        .with(CircleCollider { radius })
         .with(Enemy)
         .with(Velocity {
             value: Vector3::new(x_vel, y_vel, 0.0),

--- a/src/scenes/mod.rs
+++ b/src/scenes/mod.rs
@@ -91,10 +91,11 @@ pub fn initialize_enemies_scaled(world: &mut World) {
 
     let area = ARENA_WIDTH * ARENA_HEIGHT;
     // We want circles to cover 80% of the area
-    #[allow(clippy::cast_precision_loss)]
-    let size = ((area * area_scale) / (enemy_count as f32 * std::f32::consts::PI)).sqrt();
 
-    initialize_enemies(world, enemy_count, size);
+    #[allow(clippy::cast_precision_loss)]
+    let radius = ((area * area_scale) / (enemy_count as f32 * std::f32::consts::PI)).sqrt();
+
+    initialize_enemies(world, enemy_count, radius);
 }
 
 fn get_variable<F: std::str::FromStr>(variable: &str, default: F) -> F {
@@ -118,13 +119,13 @@ fn get_area_scale() -> f32 {
     get_variable("AREA_SCALE", 0.8)
 }
 
-fn initialize_enemies(world: &mut World, count: usize, size: f32) {
+fn initialize_enemies(world: &mut World, count: usize, radius: f32) {
     use rand::distributions::{Distribution, Uniform};
     let mut rng = rand::thread_rng();
     let direction = Uniform::new(-1.0, 1.0);
-    let velocity = Uniform::new(f32::EPSILON, 12.5 * size);
-    let enemy_x = Uniform::new(size, ARENA_WIDTH - size);
-    let enemy_y = Uniform::new(size, ARENA_HEIGHT - size);
+    let velocity = Uniform::new(f32::EPSILON, 12.5 * radius);
+    let enemy_x = Uniform::new(radius, ARENA_WIDTH - radius);
+    let enemy_y = Uniform::new(radius, ARENA_HEIGHT - radius);
     for _ in 1..=count {
         enemy::spawn_enemy(
             world,
@@ -132,7 +133,7 @@ fn initialize_enemies(world: &mut World, count: usize, size: f32) {
             enemy_y.sample(&mut rng),
             direction.sample(&mut rng) * velocity.sample(&mut rng),
             direction.sample(&mut rng) * velocity.sample(&mut rng),
-            size,
+            radius,
         );
     }
 }

--- a/src/scenes/mod.rs
+++ b/src/scenes/mod.rs
@@ -81,6 +81,7 @@ pub fn initialize_enemies_bench(world: &mut World) {
 
 pub fn initialize_enemies_scaled(world: &mut World) {
     let enemy_count = get_enemy_count();
+    // The percentage of the screen that should be covered in colliders
     let area_scale = get_area_scale();
 
     log::info!(
@@ -90,7 +91,6 @@ pub fn initialize_enemies_scaled(world: &mut World) {
     );
 
     let area = ARENA_WIDTH * ARENA_HEIGHT;
-    // We want circles to cover 80% of the area
 
     #[allow(clippy::cast_precision_loss)]
     let radius = ((area * area_scale) / (enemy_count as f32 * std::f32::consts::PI)).sqrt();
@@ -116,7 +116,7 @@ fn get_enemy_count() -> usize {
 }
 
 fn get_area_scale() -> f32 {
-    get_variable("AREA_SCALE", 0.8)
+    get_variable("AREA_SCALE", 0.4)
 }
 
 fn initialize_enemies(world: &mut World, count: usize, radius: f32) {

--- a/src/scenes/mod.rs
+++ b/src/scenes/mod.rs
@@ -88,24 +88,20 @@ pub fn initialize_enemies_bench(world: &mut World) {
 
 fn initialize_enemies(world: &mut World, count: usize) {
     use rand::distributions::{Distribution, Uniform};
+    let size = 4.0;
     let mut rng = rand::thread_rng();
     let direction = Uniform::new(-1.0, 1.0);
-    let velocity = Uniform::new(f32::EPSILON, 50.0);
-    let enemy_x = Uniform::new(
-        enemy::HITCIRCLE_RADIUS,
-        ARENA_WIDTH - enemy::HITCIRCLE_RADIUS,
-    );
-    let enemy_y = Uniform::new(
-        enemy::HITCIRCLE_RADIUS,
-        ARENA_HEIGHT - enemy::HITCIRCLE_RADIUS,
-    );
+    let velocity = Uniform::new(f32::EPSILON, 12.5 * size);
+    let enemy_x = Uniform::new(size, ARENA_WIDTH - size);
+    let enemy_y = Uniform::new(size, ARENA_HEIGHT - size);
     for _ in 1..=count {
         enemy::spawn_enemy(
             world,
-            direction.sample(&mut rng) * enemy_x.sample(&mut rng),
-            direction.sample(&mut rng) * enemy_y.sample(&mut rng),
-            velocity.sample(&mut rng),
-            velocity.sample(&mut rng),
+            enemy_x.sample(&mut rng),
+            enemy_y.sample(&mut rng),
+            direction.sample(&mut rng) * velocity.sample(&mut rng),
+            direction.sample(&mut rng) * velocity.sample(&mut rng),
+            size,
         );
     }
 }

--- a/src/states/running.rs
+++ b/src/states/running.rs
@@ -69,7 +69,7 @@ impl SimpleState for RunningState {
             // only starts counting AFTER everything is initialized
             bench.advance_frame(time.delta_time().as_secs_f64());
 
-            if time.absolute_time_seconds() > 30_f64 {
+            if bench.should_end() {
                 return SimpleTrans::Quit;
             }
         }

--- a/src/systems/score.rs
+++ b/src/systems/score.rs
@@ -46,7 +46,7 @@ impl<'a, 'b> SystemDesc<'a, 'b, ScoreSystem> for ScoreSystemDesc {
             0_f32,
             0_f32,
             0_f32,
-            200_f32,
+            100e20_f32,
             50_f32,
         );
         let player_score_entity = world

--- a/src/util/frame_bench.rs
+++ b/src/util/frame_bench.rs
@@ -78,6 +78,10 @@ pub struct FrameBench {
 }
 
 impl FrameBench {
+    pub fn should_end(&self) -> bool {
+        self.main.total >= 30.0
+    }
+
     pub fn advance_frame(&mut self, delta_time: f64) {
         self.main.advance_frame(delta_time);
     }


### PR DESCRIPTION
Creates a new benchmark scene that holds collider density constant across enemy_count. Density is also parameterized as well. 

This allows the enemy count to be scaled up while still making sure the usage is similar to how it would be used in a real game. 

Brings the 5000 enemy count benchmark to an average of 25 collisions per collider per frame down to 0.4 collisions per collider per frame.

Also changes the bench kill timer to use time in the running state rather than absolute time. 